### PR TITLE
feat: filter by supported version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "semver": "^7.3.4",
+    "semver-compare": "^1.0.0",
     "unist-util-visit-parents": "^3.1.1"
   },
   "devDependencies": {
@@ -34,6 +35,7 @@
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
     "@types/semver": "^7.3.4",
+    "@types/semver-compare": "^1.0.1",
     "netlify-cli": "^6.8.14",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import { AppProps } from "next/app";
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider } from "@chakra-ui/react";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2627,6 +2627,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
+"@types/semver-compare@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver-compare/-/semver-compare-1.0.1.tgz#17d1dc62c516c133ab01efb7803a537ee6eaf3d5"
+  integrity sha512-wx2LQVvKlEkhXp/HoKIZ/aSL+TvfJdKco8i0xJS3aR877mg4qBHzNT6+B5a61vewZHo79EdZavskGnRXEC2H6A==
+
 "@types/semver@^7.0.0":
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
@@ -9054,6 +9059,11 @@ seek-bzip@^1.0.5:
   integrity sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==
   dependencies:
     commander "^2.8.1"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
I would like to filter APIs by `supported`, so I can check new APIs added after my specific version. 
![filter-by-supported](https://user-images.githubusercontent.com/127635/133200639-4a1f6568-19c1-48b7-9642-4f096168066e.gif)

[sermver-compare](https://www.npmjs.com/package/semver-compare) is used to compare versions.
